### PR TITLE
Handle optional parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-filter",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Runtime-checking tool for typescript",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/io-filter/ExistsFilter.ts
+++ b/src/io-filter/ExistsFilter.ts
@@ -6,8 +6,8 @@ import {MaskFilter} from "./MaskFilter";
  */
 export class ExistsFilter extends MaskFilter {
 
-    public mask(object: any): any {
-        return typeof object !== 'undefined' ? object : undefined;
+    public maskObject(object: any): any {
+        return object;
     }
 
     public toString(): string {

--- a/src/io-filter/NumberFilter.ts
+++ b/src/io-filter/NumberFilter.ts
@@ -28,7 +28,7 @@ export class NumberFilter extends MaskFilter {
         this.allowCasting = typeof allowCasting === 'undefined' || allowCasting;
     }
 
-    public mask(object: any): any {
+    public maskObject(object: any): any {
         let parsed: number = NaN;
         if (this.allowCasting && typeof object === 'string')
             parsed = parseFloat(object);
@@ -36,7 +36,7 @@ export class NumberFilter extends MaskFilter {
             parsed = object as number;
 
         if (isNaN(parsed) || parsed < this.min || parsed > this.max)
-            return;
+            this.failWith("The given object " + object + " is not a number");
 
         return parsed;
     }

--- a/src/io-filter/ObjectFilter.ts
+++ b/src/io-filter/ObjectFilter.ts
@@ -18,22 +18,16 @@ export class ObjectFilter extends MaskFilter {
         this.elements = elements;
     }
 
-    public mask(object: any): any {
+    public maskObject(object: any): any {
         // if the object is null
         if (object == null)
-            return undefined;
+            this.failWith("Object is null");
         // prepare the resulting filtered object
         let filtered: any = {};
         // for each expected property
         for (let name in this.elements) {
-            // if the property is not set
-            if (typeof object[name] === 'undefined')
-                return undefined;
             // apply the mask on the child property
             filtered[name] = this.elements[name].mask(object[name]);
-            // if the property fails the filter
-            if (typeof filtered[name] === 'undefined')
-                return undefined;
         }
         // return the filtered object
         return filtered;

--- a/src/io-filter/RegExpFilter.ts
+++ b/src/io-filter/RegExpFilter.ts
@@ -14,8 +14,10 @@ export class RegExpFilter extends MaskFilter {
         this.regexp = regexp;
     }
 
-    public mask(object: any): any {
-        return typeof object == 'string' && this.regexp.test(object) ? object as string : undefined;
+    public maskObject(object: any): any {
+        if (typeof object !== "string" || ! this.regexp.test(object))
+            this.failWith(object + " does not pass the RegExp");
+        return object;
     }
 
     public toString(): string {

--- a/src/io-filter/ValueTypeFilter.ts
+++ b/src/io-filter/ValueTypeFilter.ts
@@ -13,8 +13,10 @@ export class ValueTypeFilter extends MaskFilter {
         this.type = type;
     }
 
-    public mask(object: any): any {
-        return typeof object == this.type ? object : undefined;
+    public maskObject(object: any): any {
+        if (typeof object !== this.type)
+            this.failWith(object + " is not of the expected type");
+        return object;
     }
 
     public toString(): string {


### PR DESCRIPTION
This PR includes:
- changes required to throw an error instead of returning undefined when the filter fails
- .asOptional() modifier for filters to specify that the value is optional (default: false)